### PR TITLE
Add Ko-fi tip link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ npm test
 npm run build
 ```
 
+## Support
+
+I build and maintain projects like crono in my free time as personal hobbies. They're completely free and always will be. If you find this useful and want to show some support, feel free to buy me a coffee:
+
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/milldr)
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Adds a Ko-fi tip link as a GitHub admonition in the README, placed after the demo GIF

## Test plan
- [ ] Verify the `[!TIP]` admonition renders correctly on GitHub
- [ ] Verify the Ko-fi link points to https://ko-fi.com/milldr