### PR TITLE
Auto-set package version from release tag

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,9 +29,11 @@ version-resolver:
     labels:
       - "minor"
       - "feature"
+      - "enhancement"
   patch:
     labels:
       - "patch"
       - "fix"
       - "bugfix"
-  default: patch
+      - "bug"
+  default: minor

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Set version from release tag
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          echo "Setting package version to $VERSION"
+          npm version "$VERSION" --no-git-tag-version
+
       - name: Check formatting
         run: npm run format:check
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@milldr/crono",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "CLI for Cronometer automation via Kernel.sh",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Publish workflow now extracts the version from the release tag and sets it in `package.json` before `npm publish`, so the repo no longer needs manual version bumps to publish correctly
- Release Drafter default changed from `patch` to `minor`, and added `enhancement`/`bug` labels to version-resolver so changelog categories correctly map to version bumps
- Bumped `package.json` to `0.2.0`
- Created GitHub labels (`major`, `minor`, `patch`, `feature`, `fix`, `bugfix`, `no release`, `docs`) and cleaned up the failed `v0.1.1` release

## Test plan

- [ ] Merge this PR, verify Release Drafter creates a draft targeting `v0.2.0`
- [ ] Publish the draft release, verify `npm view @milldr/crono version` returns `0.2.0`