### PR TITLE
Fix publish workflow: allow same version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           VERSION="${{ github.event.release.tag_name }}"
           VERSION="${VERSION#v}"
           echo "Setting package version to $VERSION"
-          npm version "$VERSION" --no-git-tag-version
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Check formatting
         run: npm run format:check


### PR DESCRIPTION
## Summary

- Add `--allow-same-version` to the `npm version` step in the publish workflow
- Fixes failure when `package.json` version already matches the release tag (npm errors with "Version not changed")

## Test plan

- [ ] Merge, publish release, verify npm publish succeeds