### PR TITLE
Fix npm publish: clear NODE_AUTH_TOKEN for OIDC auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,5 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ""


### PR DESCRIPTION
## Summary

- The `setup-node` action injects the `GITHUB_TOKEN` as `NODE_AUTH_TOKEN` when `registry-url` is set. npm then tries to authenticate to the npm registry with this GitHub token, which fails with "Access token expired or revoked."
- Fix: explicitly set `NODE_AUTH_TOKEN` to empty string on the publish step so npm falls through to OIDC trusted publisher authentication.

## Test plan

- [ ] Merge, delete the failed v0.2.0 release/tag, publish a new release, verify npm publish succeeds