### PR TITLE
Fix npm publish: use NPM_TOKEN for registry auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Publish to npm
         run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ""
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Use `NPM_TOKEN` repo secret for npm registry authentication instead of empty string
- OIDC trusted publisher handles provenance attestation, but auth still requires a real npm token

## Test plan

- [ ] Merge, delete failed v0.2.0 release/tag, publish new release, verify npm publish succeeds