### PR TITLE
Fix publish: use npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,9 @@ jobs:
         with:
           node-version: 22
           cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -46,5 +48,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove `registry-url` from `setup-node` — it was injecting `GITHUB_TOKEN` as `NODE_AUTH_TOKEN`, overriding OIDC auth
- Upgrade npm to latest (>=11.5) in CI — OIDC trusted publishing auth requires npm 11.5+
- Remove `NODE_AUTH_TOKEN` env — OIDC handles authentication, no token needed

## Test plan

- [ ] Merge, delete failed v0.2.0 release/tag, publish new release
- [ ] Verify npm publish succeeds without any npm token secret