### PR TITLE
Add repository URL to package.json for provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "automation",
     "kernel"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/milldr/crono"
+  },
   "author": "Daniel Miller",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary

- Add `repository` field to `package.json` pointing to `https://github.com/milldr/crono`
- npm provenance validation requires this field to match the GitHub repo in the OIDC token

## Test plan

- [ ] Merge, delete failed v0.2.0 release/tag, publish new release, verify npm publish succeeds