### PR TITLE
Fix quick-add hang on dialog overlay

### DIFF
--- a/tests/kernel/quick-add.test.ts
+++ b/tests/kernel/quick-add.test.ts
@@ -85,6 +85,33 @@ describe("buildQuickAddCode", () => {
     expect(code).toContain("return { success: true }");
   });
 
+  it("should include click timeouts in helper functions", () => {
+    const code = buildQuickAddCode({ protein: 30 });
+    expect(code).toContain("click({ timeout: 5000 })");
+    expect(code).toContain("click({ button: 'right', timeout: 5000 })");
+  });
+
+  it("should check dialog dismissal instead of silently catching", () => {
+    const code = buildQuickAddCode({ protein: 30 });
+    expect(code).toContain("dialogDismissed");
+    expect(code).toContain("dialog did not close");
+    expect(code).not.toMatch(
+      /waitForSelector\('text="Add Food to Diary"',\s*\{\s*state:\s*'hidden'[^)]*\)\.catch\(\(\)\s*=>\s*\{\s*\}\)/
+    );
+  });
+
+  it("should check context menu visibility instead of silently catching", () => {
+    const code = buildQuickAddCode({ protein: 30 });
+    expect(code).toContain("menuVisible");
+    expect(code).toContain("Context menu did not appear");
+  });
+
+  it("should check search results instead of silently catching", () => {
+    const code = buildQuickAddCode({ protein: 30 });
+    expect(code).toContain("resultsAppeared");
+    expect(code).toContain("Search results did not appear");
+  });
+
   it("should navigate to target date using prev-day arrows when date is provided", () => {
     const code = buildQuickAddCode({ protein: 30, date: "2026-02-10" });
     expect(code).toContain('"2026-02-10"');


### PR DESCRIPTION
## What

Replace silent `.catch(() => {})` handlers in quick-add Playwright codegen with explicit result checks, and add click timeouts to helper functions. This prevents the CLI from hanging indefinitely when a dialog overlay obscures clickable elements between loop iterations.

## Why

`crono quick-add` hangs requiring SIGKILL because Playwright's `.click()` blocks forever when the "Add Food to Diary" dialog from the previous iteration isn't confirmed dismissed. Silent catches masked timeout failures, allowing the code to proceed into broken states.

## Ref

- Closes #18