### PR TITLE
fix: read CLI version from package.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createRequire } from "node:module";
 import { Command } from "commander";
 import { login } from "./commands/login.js";
 import { quickAdd } from "./commands/quick-add.js";
@@ -9,12 +10,15 @@ import { diary } from "./commands/diary.js";
 import { weight } from "./commands/weight.js";
 import { exportCmd } from "./commands/export.js";
 
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json");
+
 const program = new Command();
 
 program
   .name("crono")
   .description("CLI for Cronometer automation via Kernel.sh")
-  .version("0.1.0");
+  .version(version);
 
 program
   .command("login")


### PR DESCRIPTION
## What
Read the CLI `--version` value from `package.json` at runtime using `createRequire`, instead of a hardcoded `"0.1.0"` string.

## Why
The version reported by `crono --version` was always `0.1.0` regardless of the actual published version. The release workflow already syncs `package.json` version from the git tag before publishing, so reading from `package.json` makes the version automatically correct for every release — no manual updates needed.