### PR TITLE
fix: retry right-click context menu for flaky GWT interactions

### DIFF
--- a/src/kernel/add-custom-food.ts
+++ b/src/kernel/add-custom-food.ts
@@ -205,17 +205,28 @@ export function buildAddCustomFoodCode(entry: CustomFoodEntry): string {
         return false;
       }
 
-      // Right-click the meal category
-      const mealClicked = await rightClickFirst([
-        'text="' + mealLabel + '"',
-        ':has-text("' + mealLabel + '")',
-      ], 'meal category');
-      if (!mealClicked) {
-        return { success: false, error: 'Food created but could not find meal category "' + mealLabel + '" in diary' };
+      // Right-click meal category with retry (GWT context menus can be flaky)
+      let menuVisible = false;
+      for (let attempt = 0; attempt < 3 && !menuVisible; attempt++) {
+        if (attempt > 0) {
+          await page.keyboard.press('Escape');
+          await page.mouse.click(1, 1);
+          await page.waitForTimeout(1000);
+        }
+        const mealClicked = await rightClickFirst([
+          'text="' + mealLabel + '"',
+          ':has-text("' + mealLabel + '")',
+        ], 'meal category');
+        if (!mealClicked) {
+          return { success: false, error: 'Food created but could not find meal category "' + mealLabel + '" in diary' };
+        }
+        menuVisible = await page.waitForSelector('text="Add Food..."', { timeout: 3000 })
+          .then(() => true)
+          .catch(() => page.waitForSelector('text="Add Food"', { timeout: 2000 }).then(() => true).catch(() => false));
       }
-      await page.waitForSelector('text="Add Food..."', { timeout: 3000 }).catch(() =>
-        page.waitForSelector('text="Add Food"', { timeout: 2000 }).catch(() => {})
-      );
+      if (!menuVisible) {
+        return { success: false, error: 'Food created but context menu did not appear after right-clicking "' + mealLabel + '"' };
+      }
 
       // Click "Add Food..." in context menu
       const addFoodClicked = await clickFirst([

--- a/src/kernel/log-food.ts
+++ b/src/kernel/log-food.ts
@@ -68,17 +68,28 @@ export function buildLogFoodCode(entry: LogFoodEntry): string {
       return false;
     }
 
-    // Right-click the meal category
-    const clicked = await rightClickFirst([
-      'text="' + mealLabel + '"',
-      ':has-text("' + mealLabel + '")',
-    ], 'meal category');
-    if (!clicked) {
-      return { success: false, error: 'Could not find meal category "' + mealLabel + '" in diary' };
+    // Right-click meal category with retry (GWT context menus can be flaky)
+    let menuVisible = false;
+    for (let attempt = 0; attempt < 3 && !menuVisible; attempt++) {
+      if (attempt > 0) {
+        await page.keyboard.press('Escape');
+        await page.mouse.click(1, 1);
+        await page.waitForTimeout(1000);
+      }
+      const clicked = await rightClickFirst([
+        'text="' + mealLabel + '"',
+        ':has-text("' + mealLabel + '")',
+      ], 'meal category');
+      if (!clicked) {
+        return { success: false, error: 'Could not find meal category "' + mealLabel + '" in diary' };
+      }
+      menuVisible = await page.waitForSelector('text="Add Food..."', { timeout: 3000 })
+        .then(() => true)
+        .catch(() => page.waitForSelector('text="Add Food"', { timeout: 2000 }).then(() => true).catch(() => false));
     }
-    await page.waitForSelector('text="Add Food..."', { timeout: 3000 }).catch(() =>
-      page.waitForSelector('text="Add Food"', { timeout: 2000 }).catch(() => {})
-    );
+    if (!menuVisible) {
+      return { success: false, error: 'Context menu did not appear after right-clicking "' + mealLabel + '"' };
+    }
 
     // Click "Add Food..." in context menu
     const addFoodClicked = await clickFirst([

--- a/src/kernel/quick-add.ts
+++ b/src/kernel/quick-add.ts
@@ -125,17 +125,26 @@ export function buildQuickAddCode(entry: MacroEntry): string {
 
     // Add each macro as a separate food entry
     for (const macro of macros) {
-      // Right-click the meal category
-      const clicked = await rightClickFirst([
-        'text="' + mealLabel + '"',
-        ':has-text("' + mealLabel + '")',
-      ]);
-      if (!clicked) {
-        return { success: false, error: 'Could not find meal category "' + mealLabel + '" in diary' };
+      // Right-click meal category with retry (GWT context menus can be flaky)
+      let menuVisible = false;
+      for (let attempt = 0; attempt < 3 && !menuVisible; attempt++) {
+        if (attempt > 0) {
+          // Dismiss any stale state by pressing Escape and clicking away
+          await page.keyboard.press('Escape');
+          await page.mouse.click(1, 1);
+          await page.waitForTimeout(1000);
+        }
+        const clicked = await rightClickFirst([
+          'text="' + mealLabel + '"',
+          ':has-text("' + mealLabel + '")',
+        ]);
+        if (!clicked) {
+          return { success: false, error: 'Could not find meal category "' + mealLabel + '" in diary' };
+        }
+        menuVisible = await page.waitForSelector('text="Add Food..."', { timeout: 3000 })
+          .then(() => true)
+          .catch(() => page.waitForSelector('text="Add Food"', { timeout: 2000 }).then(() => true).catch(() => false));
       }
-      const menuVisible = await page.waitForSelector('text="Add Food..."', { timeout: 3000 })
-        .then(() => true)
-        .catch(() => page.waitForSelector('text="Add Food"', { timeout: 2000 }).then(() => true).catch(() => false));
       if (!menuVisible) {
         return { success: false, error: 'Context menu did not appear after right-clicking "' + mealLabel + '"' };
       }

--- a/tests/kernel/log-food.test.ts
+++ b/tests/kernel/log-food.test.ts
@@ -39,6 +39,13 @@ describe("buildLogFoodCode", () => {
     expect(code).toContain("addFoodClicked");
   });
 
+  it("should retry right-click up to 3 times when context menu fails to appear", () => {
+    const code = buildLogFoodCode({ name: "Test Food" });
+    expect(code).toContain("attempt < 3");
+    expect(code).toContain("menuVisible");
+    expect(code).toContain("Context menu did not appear");
+  });
+
   it("should search in the food search bar", () => {
     const code = buildLogFoodCode({ name: "Test Food" });
     expect(code).toContain("SEARCH");

--- a/tests/kernel/quick-add.test.ts
+++ b/tests/kernel/quick-add.test.ts
@@ -106,6 +106,12 @@ describe("buildQuickAddCode", () => {
     expect(code).toContain("Context menu did not appear");
   });
 
+  it("should retry right-click up to 3 times when context menu fails to appear", () => {
+    const code = buildQuickAddCode({ protein: 30 });
+    expect(code).toContain("attempt < 3");
+    expect(code).toContain("Escape");
+  });
+
   it("should check search results instead of silently catching", () => {
     const code = buildQuickAddCode({ protein: 30 });
     expect(code).toContain("resultsAppeared");


### PR DESCRIPTION
## What

Adds a retry loop (up to 3 attempts) around the right-click → context menu detection in all three commands that use it: quick-add, log-food, and add-custom-food. Between retries, dismisses stale state with Escape + click-away and waits 1s for the GWT app to stabilize.

## Why

Cronometer's GWT-based UI intermittently fails to show the context menu after a right-click, causing `quick-add` (and other commands) to fail with "Context menu did not appear after right-clicking". A single retry attempt is insufficient for a flaky UI interaction — 3 attempts with cleanup between each makes this robust.

## Ref

Reported via CLI: `crono quick-add -p 1 --meal Dinner` → "Context menu did not appear after right-clicking Dinner"