### PR TITLE
feat: add `servings` export type for per-food-entry queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,32 +293,46 @@ crono export <type> [options]
 
 **Types:**
 
-| Type         | Description                         |
-| ------------ | ----------------------------------- |
-| `nutrition`  | Daily nutrition totals (macros)     |
-| `exercises`  | Exercise entries with duration/cals |
-| `biometrics` | Biometric measurements (weight, BP) |
+| Type         | Granularity        | Description                                                                                   |
+| ------------ | ------------------ | --------------------------------------------------------------------------------------------- |
+| `nutrition`  | Daily totals       | Aggregated calories + 60+ nutrient columns (vitamins, minerals, amino acids, omega 3/6, etc.) |
+| `servings`   | Per food entry     | Time, meal, food name, amount, full nutrient breakdown — answers "what did I have for dinner" |
+| `exercises`  | Per exercise entry | Time, exercise name, duration, calories burned, group                                         |
+| `biometrics` | Per measurement    | Weight, BP, plus anything Apple Health pushes in (heart rate, HRV, sleep)                     |
 
 **Options:**
 
-| Flag | Long              | Description                               |
-| ---- | ----------------- | ----------------------------------------- |
-| `-d` | `--date <date>`   | Date (YYYY-MM-DD)                         |
-| `-r` | `--range <range>` | Range (7d, 30d, or YYYY-MM-DD:YYYY-MM-DD) |
-|      | `--csv`           | Output as raw CSV                         |
-|      | `--json`          | Output as JSON                            |
+| Flag | Long              | Description                                                             |
+| ---- | ----------------- | ----------------------------------------------------------------------- |
+| `-d` | `--date <date>`   | Date (YYYY-MM-DD)                                                       |
+| `-r` | `--range <range>` | Range (7d, 30d, or YYYY-MM-DD:YYYY-MM-DD)                               |
+| `-m` | `--meal <name>`   | `servings` only: filter to a meal (Breakfast / Lunch / Dinner / Snacks) |
+|      | `--csv`           | Output as raw CSV                                                       |
+|      | `--json`          | Output as JSON                                                          |
 
 `-d` and `-r` are mutually exclusive. `--csv` and `--json` are mutually exclusive.
 
 **Examples:**
 
 ```bash
-# Today's nutrition
+# Today's nutrition (daily totals)
 crono export nutrition
 # → 1847 kcal | P: 168g | C: 142g | F: 58g
 
 # Last 7 days of nutrition as JSON
 crono export nutrition -r 7d --json
+
+# What did I have for dinner today? (per-food breakdown)
+crono export servings -m Dinner
+# → 7:30 PM | Dinner | Beef Steak | 150g | 306 kcal | P: 46g  C: 0g  F: 13.5g
+# → ...
+# → Total: 672 kcal | P: 70.1g  C: 43.5g  F: 34.3g
+
+# Yesterday's full food log
+crono export servings -d yesterday
+
+# Last 7 days of food entries as JSON (each entry includes all 60+ nutrient columns)
+crono export servings -r 7d --json
 
 # Today's exercises
 crono export exercises

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -5,19 +5,27 @@ import {
   parseNutrition,
   parseExercises,
   parseBiometrics,
+  parseServings,
   type NutritionEntry,
   type ExerciseEntry,
   type BiometricEntry,
+  type ServingEntry,
 } from "../cronometer/parse.js";
 import { parseDate, parseRange, todayStr } from "../utils/date.js";
 
-const VALID_TYPES = ["nutrition", "exercises", "biometrics"] as const;
+const VALID_TYPES = [
+  "nutrition",
+  "exercises",
+  "biometrics",
+  "servings",
+] as const;
 
 export interface ExportOptions {
   date?: string;
   range?: string;
   csv?: boolean;
   json?: boolean;
+  meal?: string;
 }
 
 export async function exportCmd(
@@ -26,7 +34,9 @@ export async function exportCmd(
 ): Promise<void> {
   // Validate type
   if (!VALID_TYPES.includes(type as ExportType)) {
-    p.log.error("Unknown export type. Use: nutrition, exercises, biometrics");
+    p.log.error(
+      "Unknown export type. Use: nutrition, exercises, biometrics, servings"
+    );
     process.exit(1);
   }
 
@@ -87,6 +97,27 @@ export async function exportCmd(
 
     // Parse and output
     const exportType = type as ExportType;
+    if (exportType === "servings") {
+      let entries = parseServings(csv);
+      if (options.meal) {
+        const target = options.meal.toLowerCase();
+        entries = entries.filter((e) => e.meal.toLowerCase() === target);
+      }
+      if (entries.length === 0) {
+        if (!silent) {
+          const suffix = options.meal ? ` for meal "${options.meal}"` : "";
+          p.outro(`No servings found${suffix}`);
+        }
+        return;
+      }
+      if (options.json) {
+        console.log(JSON.stringify(isRange ? entries : entries, null, 2));
+      } else {
+        formatServings(entries, isRange);
+      }
+      return;
+    }
+
     if (exportType === "nutrition") {
       const entries = parseNutrition(csv);
       if (entries.length === 0) {
@@ -154,6 +185,28 @@ function formatExercises(entries: ExerciseEntry[], isRange: boolean): void {
   for (const e of entries) {
     p.log.info(
       `${e.date}: ${e.exercise}: ${e.minutes} min, ${e.caloriesBurned} kcal`
+    );
+  }
+}
+
+function formatServings(entries: ServingEntry[], isRange: boolean): void {
+  const datePrefix = isRange;
+  for (const e of entries) {
+    const prefix = datePrefix ? `${e.date} ` : "";
+    p.log.info(
+      `${prefix}${e.time} | ${e.meal} | ${e.food} | ${e.amount} | ${e.calories} kcal | P: ${e.protein}g  C: ${e.carbs}g  F: ${e.fat}g`
+    );
+  }
+
+  // Totals (useful when filtering by meal or showing one day)
+  if (entries.length > 1) {
+    const totalCal = entries.reduce((s, e) => s + e.calories, 0);
+    const totalP = entries.reduce((s, e) => s + e.protein, 0);
+    const totalC = entries.reduce((s, e) => s + e.carbs, 0);
+    const totalF = entries.reduce((s, e) => s + e.fat, 0);
+    p.log.info("───");
+    p.log.info(
+      `Total: ${totalCal.toFixed(0)} kcal | P: ${totalP.toFixed(1)}g  C: ${totalC.toFixed(1)}g  F: ${totalF.toFixed(1)}g`
     );
   }
 }

--- a/src/cronometer/export.ts
+++ b/src/cronometer/export.ts
@@ -14,12 +14,13 @@ const BASE_URL = "https://cronometer.com";
 const DEFAULT_GWT_PERMUTATION = "7B121DC5483BF272B1BC1916DA9FA963";
 const DEFAULT_GWT_HEADER = "2D6A926E3729946302DC68073CB0D550";
 
-export type ExportType = "nutrition" | "exercises" | "biometrics";
+export type ExportType = "nutrition" | "exercises" | "biometrics" | "servings";
 
 const EXPORT_TYPE_MAP: Record<ExportType, string> = {
   nutrition: "dailySummary",
   exercises: "exercises",
   biometrics: "biometrics",
+  servings: "servings",
 };
 
 /** Build GWT RPC body for generateAuthorizationToken. */

--- a/src/cronometer/parse.ts
+++ b/src/cronometer/parse.ts
@@ -31,6 +31,20 @@ export interface BiometricEntry {
   amount: number | string;
 }
 
+export interface ServingEntry {
+  date: string;
+  time: string;
+  meal: string;
+  food: string;
+  amount: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  category: string;
+  [key: string]: string | number;
+}
+
 /** Parse a CSV string into rows of string arrays. Handles quoted fields. */
 export function parseCSV(csv: string): string[][] {
   const lines = csv.trim().split("\n");
@@ -152,6 +166,72 @@ export function parseExercises(csv: string): ExerciseEntry[] {
       caloriesBurned: num(row[caloriesIdx]),
       group: row[groupIdx]?.trim() ?? "",
     });
+  }
+
+  return entries;
+}
+
+export function parseServings(csv: string): ServingEntry[] {
+  const rows = parseCSV(csv);
+  if (rows.length < 2) return [];
+
+  const headers = rows[0];
+  const dayIdx = colIndex(headers, "Day");
+  const timeIdx = colIndex(headers, "Time");
+  const groupIdx = colIndex(headers, "Group");
+  const foodIdx = colIndex(headers, "Food Name");
+  const amountIdx = colIndex(headers, "Amount");
+  const energyIdx = colIndex(headers, "Energy (kcal)");
+  const proteinIdx = colIndex(headers, "Protein (g)");
+  const carbsIdx = colIndex(headers, "Carbs (g)");
+  const fatIdx = colIndex(headers, "Fat (g)");
+  const categoryIdx = colIndex(headers, "Category");
+
+  if (dayIdx === -1) return [];
+
+  const entries: ServingEntry[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i];
+    const date = row[dayIdx]?.trim();
+    if (!date) continue;
+
+    const entry: ServingEntry = {
+      date,
+      time: row[timeIdx]?.trim() ?? "",
+      meal: row[groupIdx]?.trim() ?? "",
+      food: row[foodIdx]?.trim() ?? "",
+      amount: row[amountIdx]?.trim() ?? "",
+      calories: num(row[energyIdx]),
+      protein: num(row[proteinIdx]),
+      carbs: num(row[carbsIdx]),
+      fat: num(row[fatIdx]),
+      category: row[categoryIdx]?.trim() ?? "",
+    };
+
+    // Include all other nutrient columns for full JSON output
+    const surfacedIdxs = new Set([
+      dayIdx,
+      timeIdx,
+      groupIdx,
+      foodIdx,
+      amountIdx,
+      energyIdx,
+      proteinIdx,
+      carbsIdx,
+      fatIdx,
+      categoryIdx,
+    ]);
+    for (let j = 0; j < headers.length; j++) {
+      if (surfacedIdxs.has(j)) continue;
+      const key = headers[j].trim();
+      const val = row[j]?.trim() ?? "";
+      if (key && val !== "") {
+        const parsed = parseFloat(val);
+        entry[key] = isNaN(parsed) ? val : parsed;
+      }
+    }
+
+    entries.push(entry);
   }
 
   return entries;

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,9 +96,15 @@ program
 
 program
   .command("export <type>")
-  .description("Export data from Cronometer (nutrition, exercises, biometrics)")
+  .description(
+    "Export data from Cronometer (nutrition, exercises, biometrics, servings)"
+  )
   .option("-d, --date <date>", "Date (YYYY-MM-DD)")
   .option("-r, --range <range>", "Range (7d, 30d, or YYYY-MM-DD:YYYY-MM-DD)")
+  .option(
+    "-m, --meal <name>",
+    "Filter servings by meal (Breakfast, Lunch, Dinner, Snacks)"
+  )
   .option("--csv", "Output as CSV")
   .option("--json", "Output as JSON")
   .action(async (type, options) => {

--- a/tests/cronometer/parse.test.ts
+++ b/tests/cronometer/parse.test.ts
@@ -4,6 +4,7 @@ import {
   parseNutrition,
   parseExercises,
   parseBiometrics,
+  parseServings,
 } from "../../src/cronometer/parse.js";
 
 describe("parseCSV", () => {
@@ -135,5 +136,45 @@ describe("parseBiometrics", () => {
 
   it("should return empty array for empty CSV", () => {
     expect(parseBiometrics("")).toEqual([]);
+  });
+});
+
+describe("parseServings", () => {
+  const sampleCSV = `Day,Time,Group,Food Name,Amount,Energy (kcal),Protein (g),Carbs (g),Fat (g),Fiber (g),Sodium (mg),Category
+2026-02-11,07:30 PM,Dinner,"Beef Steak, Tenderloin",150.00 g,306,46.01,0,13.5,0,61.5,"Beef Products"
+2026-02-11,12:30 PM,Lunch,"Cabbage, Raw",95.00 g,26.6,0.91,6.06,0.04,2.13,15.2,"Vegetables and Vegetable Products"`;
+
+  it("should parse serving entries", () => {
+    const entries = parseServings(sampleCSV);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      date: "2026-02-11",
+      time: "07:30 PM",
+      meal: "Dinner",
+      food: "Beef Steak, Tenderloin",
+      amount: "150.00 g",
+      calories: 306,
+      protein: 46.01,
+      carbs: 0,
+      fat: 13.5,
+      category: "Beef Products",
+    });
+    expect(entries[1]).toMatchObject({
+      meal: "Lunch",
+      food: "Cabbage, Raw",
+      amount: "95.00 g",
+      calories: 26.6,
+    });
+  });
+
+  it("should include extra nutrient columns as additional keys", () => {
+    const entries = parseServings(sampleCSV);
+    expect(entries[0]["Fiber (g)"]).toBe(0);
+    expect(entries[0]["Sodium (mg)"]).toBe(61.5);
+    expect(entries[1]["Fiber (g)"]).toBe(2.13);
+  });
+
+  it("should return empty array for empty CSV", () => {
+    expect(parseServings("")).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Adds new `crono export servings` type that returns **per-food-entry** data (time, meal, food name, amount, full nutrient breakdown) instead of daily totals like `nutrition`. Fills the gap for "show me dinner last night" / "what did I eat for lunch on Tuesday" style queries — answerable via the API path, no headless browser needed.
- Adds `-m, --meal <name>` filter (servings only) for Breakfast / Lunch / Dinner / Snacks / Uncategorized.
- README updated, 3 new unit tests for `parseServings`, all 207 tests pass.

## Why

`nutrition` (daily totals via `/export?generate=dailySummary`) was the only API-backed read path, and it can't answer meal-level questions. Cronometer's `/export` endpoint also accepts `generate=servings`, which returns the full food log with timestamps, meal categories, food names, amounts, and the same 60+ nutrient columns each — enabling AI agents and scripts to answer richer questions about what was eaten without invoking the headless browser. Same auth/nonce machinery as the other export types, so the surface area added is minimal: one new entry in the type map, one parser, one filter flag, one formatter.

## Headline use case

```
$ crono export servings -m Dinner
7:30 PM | Dinner | Beef Steak Tenderloin | 150g | 306 kcal | P: 46g  C: 0g  F: 13.5g
7:54 PM | Dinner | Lime Dressing | 0.33 recipe | 42 kcal | P: 0.5g  C: 4.1g  F: 3g
8:07 PM | Dinner | Chocolate PB Cookie Dough | 1 Serving | 207 kcal | P: 19.8g  C: 21.8g  F: 10.9g
───
Total: 555 kcal | P: 66.4g  C: 25.9g  F: 27.4g
```

`--json` includes all 60+ nutrient columns per entry (fiber, sodium, vitamins, amino acids, etc.) for downstream analysis. `--csv` passes raw Cronometer CSV through unchanged.

## ⚠️ Heads up: rate limiting

While testing this, I noticed Cronometer's API rate-limits `/export` calls aggressively — back-to-back invocations even ~20–30 seconds apart return `Cronometer rate limit hit. Please wait a minute and try again.` This isn't introduced by this PR (it affects all `export` subcommands), but it's worth flagging because the new per-meal queries make multi-call workflows more attractive (e.g. "show me each of today's three meals" = 3 separate calls today). Possible follow-ups, none in scope here:

- Reuse the auth nonce / session cookie across requests in a single CLI invocation.
- Add a short-lived disk cache (e.g. `~/.config/crono/cache/` keyed by type+date range) so repeated identical queries don't re-hit the API.
- Aggregate flag like `crono export servings --by-meal` that fetches once and emits per-meal sections, avoiding multiple round trips.

Mentioning so it's on the radar — happy to follow up with one of these in a separate PR if you'd like.

## Test plan

- [x] `npm run format:check` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm test` — 207 pass (added 3 for `parseServings`)
- [x] `crono export servings` returns today's full food log
- [x] `crono export servings -m Dinner` filters correctly + emits totals row
- [x] `crono export servings -d yesterday` works with date flag
- [x] `crono export servings -r 7d --json` works with range + JSON
- [x] `crono export servings --csv` returns raw CSV (60+ nutrient columns)
- [x] Unknown export type still rejected with helpful message

🤖 Generated with [Claude Code](https://claude.com/claude-code)