### PR TITLE
Add switchable Playwright automation backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,8 @@ crono export nutrition -r 30d --csv
 
 ```json
 {
-  "useKernel": false
+  "useKernel": false,
+  "playwrightHeadless": true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,16 @@ crono export biometrics -r 30d
 crono export nutrition -r 30d --csv
 ```
 
+**Config:** `crono login` writes backend preference to `~/.config/crono/config.json`. Kernel remains the default; set `useKernel` to `false` to use a local Playwright browser profile instead:
+
+```json
+{
+  "useKernel": false
+}
+```
+
+Local Playwright session data is stored in `~/.config/crono/playwright-profile`.
+
 **GWT overrides:** If Cronometer updates break the export, override GWT values in `~/.config/crono/config.json` or via environment variables:
 
 ```bash
@@ -357,7 +367,7 @@ export CRONO_GWT_HEADER=<new-value>
 ## Requirements
 
 - Node.js 18+
-- [Kernel.sh](https://kernel.sh) account (for browser automation)
+- [Kernel.sh](https://kernel.sh) account (for Kernel browser automation)
 - [Cronometer](https://cronometer.com) account
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -357,6 +357,12 @@ crono export nutrition -r 30d --csv
 
 Local Playwright session data is stored in `~/.config/crono/playwright-profile`.
 
+When using the local Playwright backend, install the browser binaries once:
+
+```bash
+npx playwright install
+```
+
 **GWT overrides:** If Cronometer updates break the export, override GWT values in `~/.config/crono/config.json` or via environment variables:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@clack/prompts": "^1.0.0",
         "@napi-rs/keyring": "^1.2.0",
         "@onkernel/sdk": "^0.33.0",
-        "commander": "^12.0.0"
+        "commander": "^12.0.0",
+        "playwright": "^1.60.0"
       },
       "bin": {
         "crono": "dist/index.js"
@@ -3270,6 +3271,50 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "@clack/prompts": "^1.0.0",
     "@napi-rs/keyring": "^1.2.0",
     "@onkernel/sdk": "^0.33.0",
-    "commander": "^12.0.0"
+    "commander": "^12.0.0",
+    "playwright": "^1.60.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/src/automation/client.ts
+++ b/src/automation/client.ts
@@ -1,0 +1,17 @@
+import { loadConfig } from "../config.js";
+import { getKernelClient } from "../kernel/client.js";
+import { getPlaywrightClient } from "../playwright/client.js";
+import type { AutomationClient } from "./types.js";
+
+export type AutomationBackend = "kernel" | "playwright";
+
+export function getAutomationBackend(): AutomationBackend {
+  const config = loadConfig();
+  return config.useKernel === false ? "playwright" : "kernel";
+}
+
+export async function getAutomationClient(): Promise<AutomationClient> {
+  return getAutomationBackend() === "kernel"
+    ? getKernelClient()
+    : getPlaywrightClient();
+}

--- a/src/automation/runner.ts
+++ b/src/automation/runner.ts
@@ -1,0 +1,243 @@
+import * as p from "@clack/prompts";
+import { getCredential } from "../credentials.js";
+import { buildAddCustomFoodCode } from "../kernel/add-custom-food.js";
+import { buildDiaryCode } from "../kernel/diary.js";
+import { buildLogFoodCode } from "../kernel/log-food.js";
+import {
+  buildAutoLoginCode,
+  buildLoginCheckCode,
+  buildNavigateToLoginCode,
+} from "../kernel/login.js";
+import { buildQuickAddCode } from "../kernel/quick-add.js";
+import { buildWeightCode } from "../kernel/weight.js";
+import type {
+  AutomationClient,
+  AutomationRuntime,
+  AutomationRuntimeFactory,
+  CustomFoodEntry,
+  DiaryData,
+  LogFoodEntry,
+  MacroEntry,
+  PlaywrightExecutionResponse,
+  WeightData,
+} from "./types.js";
+
+export function createAutomationClient(
+  createRuntime: AutomationRuntimeFactory
+): AutomationClient {
+  return {
+    addQuickEntry: (entry: MacroEntry, onStatus?: (msg: string) => void) =>
+      withLoggedInRuntime(createRuntime, onStatus, async (runtime) => {
+        onStatus?.("Adding quick entry...");
+        const data = await executeAutomation<{
+          success: boolean;
+          error?: string;
+        }>(runtime, buildQuickAddCode(entry), 60);
+        if (!data.success) {
+          throw new Error(`Quick add failed: ${data.error ?? "Unknown error"}`);
+        }
+      }),
+    getWeight: (dates: string[], onStatus?: (msg: string) => void) =>
+      withLoggedInRuntime(createRuntime, onStatus, async (runtime) => {
+        onStatus?.("Reading weight data...");
+        const data = await executeAutomation<{
+          success: boolean;
+          entries?: WeightData[];
+          error?: string;
+        }>(runtime, buildWeightCode(dates), 60);
+        if (!data.success) {
+          throw new Error(
+            `Weight read failed: ${data.error ?? "Unknown error"}`
+          );
+        }
+        return data.entries ?? [];
+      }),
+    getDiary: (
+      dates: string[],
+      onStatus?: (msg: string) => void,
+      scrapeTargets?: boolean
+    ) =>
+      withLoggedInRuntime(createRuntime, onStatus, async (runtime) => {
+        onStatus?.("Reading diary data...");
+        const data = await executeAutomation<{
+          success: boolean;
+          entries?: DiaryData[];
+          error?: string;
+        }>(runtime, buildDiaryCode(dates, scrapeTargets), 60);
+        if (!data.success) {
+          throw new Error(
+            `Diary read failed: ${data.error ?? "Unknown error"}`
+          );
+        }
+        return data.entries ?? [];
+      }),
+    addCustomFood: (entry: CustomFoodEntry, onStatus?: (msg: string) => void) =>
+      withLoggedInRuntime(createRuntime, onStatus, async (runtime) => {
+        onStatus?.("Creating custom food...");
+        const data = await executeAutomation<{
+          success: boolean;
+          error?: string;
+        }>(runtime, buildAddCustomFoodCode(entry), 120);
+        if (!data.success) {
+          throw new Error(
+            `Custom food creation failed: ${data.error ?? "Unknown error"}`
+          );
+        }
+      }),
+    logFood: (entry: LogFoodEntry, onStatus?: (msg: string) => void) =>
+      withLoggedInRuntime(createRuntime, onStatus, async (runtime) => {
+        onStatus?.("Logging food to diary...");
+        const data = await executeAutomation<{
+          success: boolean;
+          error?: string;
+        }>(runtime, buildLogFoodCode(entry), 60);
+        if (!data.success) {
+          throw new Error(
+            `Food logging failed: ${data.error ?? "Unknown error"}`
+          );
+        }
+      }),
+  };
+}
+
+async function withLoggedInRuntime<T>(
+  createRuntime: AutomationRuntimeFactory,
+  onStatus: ((msg: string) => void) | undefined,
+  run: (runtime: AutomationRuntime) => Promise<T>
+): Promise<T> {
+  const username = getCredential("cronometer-username");
+  const password = getCredential("cronometer-password");
+  const hasAutoCredentials = !!(username && password);
+  const runtime = await createRuntime(hasAutoCredentials);
+
+  try {
+    await ensureLoggedIn(runtime, username, password, onStatus);
+
+    return await run(runtime);
+  } finally {
+    await runtime.close();
+  }
+}
+
+async function ensureLoggedIn(
+  runtime: AutomationRuntime,
+  username: string | null,
+  password: string | null,
+  onStatus?: (msg: string) => void
+): Promise<void> {
+  onStatus?.("Checking Cronometer session...");
+
+  const data = await executeAutomation<{
+    success: boolean;
+    loggedIn: boolean;
+    url: string;
+  }>(runtime, buildLoginCheckCode(), 30);
+
+  if (data.loggedIn) {
+    return;
+  }
+
+  if (username && password) {
+    await autoLogin(runtime, username, password, onStatus);
+  } else {
+    await manualLogin(runtime);
+  }
+}
+
+async function autoLogin(
+  runtime: AutomationRuntime,
+  username: string,
+  password: string,
+  onStatus?: (msg: string) => void
+): Promise<void> {
+  onStatus?.("Logging into Cronometer...");
+
+  const data = await executeAutomation<{
+    success: boolean;
+    loggedIn: boolean;
+    url: string;
+    error?: string;
+    loginError?: string | null;
+  }>(runtime, buildAutoLoginCode(username, password), 60);
+
+  if (!data.loggedIn) {
+    const pageError = data.loginError?.toLowerCase() ?? "";
+    const isRateLimited =
+      pageError.includes("too many") ||
+      pageError.includes("rate limit") ||
+      pageError.includes("try again later") ||
+      pageError.includes("temporarily");
+
+    if (isRateLimited) {
+      throw new Error(
+        `Cronometer is rate-limiting login attempts. ${data.loginError}\n` +
+          "Please wait a few minutes and try again."
+      );
+    }
+
+    throw new Error(
+      `Auto-login failed: ${data.error ?? data.loginError ?? "Login verification failed"}.\n` +
+        "Your credentials may be incorrect. Run `crono login` to update them."
+    );
+  }
+}
+
+async function manualLogin(runtime: AutomationRuntime): Promise<void> {
+  p.log.warn("No stored Cronometer credentials found.");
+  p.log.info("Tip: run `crono login` to save credentials for automatic login.");
+
+  if (runtime.liveViewUrl) {
+    p.note(runtime.liveViewUrl, "Browser Live View");
+  }
+
+  await executeAutomation(runtime, buildNavigateToLoginCode(), 30);
+  p.log.info("Please log into Cronometer in the browser above.");
+
+  const confirmation = await p.text({
+    message: "Press Enter once you've logged in...",
+    defaultValue: "",
+  });
+
+  if (p.isCancel(confirmation)) {
+    throw new Error("Login cancelled by user.");
+  }
+
+  const data = await executeAutomation<{
+    success: boolean;
+    loggedIn: boolean;
+    url: string;
+  }>(runtime, buildLoginCheckCode(), 30);
+
+  if (!data.loggedIn) {
+    throw new Error(
+      "Login verification failed. Make sure you're fully logged in and try again."
+    );
+  }
+
+  p.log.step("Logged in.");
+}
+
+async function executeAutomation<T>(
+  runtime: AutomationRuntime,
+  code: string,
+  timeoutSec: number
+): Promise<T> {
+  const response = await runtime.execute<T>(code, timeoutSec);
+  return unwrapExecutionResult(response, "Automation");
+}
+
+function unwrapExecutionResult<T>(
+  response: PlaywrightExecutionResponse<T>,
+  action: string
+): T {
+  if (!response.success) {
+    const details = response.error ?? response.stderr ?? "Unknown error";
+    throw new Error(`${action} failed: ${details}`);
+  }
+
+  if (response.result === undefined || response.result === null) {
+    throw new Error(`${action} failed: no result returned`);
+  }
+
+  return response.result;
+}

--- a/src/automation/types.ts
+++ b/src/automation/types.ts
@@ -1,0 +1,87 @@
+export interface MacroEntry {
+  protein?: number;
+  carbs?: number;
+  fat?: number;
+  alcohol?: number;
+  meal?: string;
+  date?: string;
+}
+
+export interface WeightData {
+  date: string;
+  weight: number | null;
+  unit: string;
+}
+
+export interface DiaryData {
+  date: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  targets?: {
+    calories: number | null;
+    protein: number | null;
+    carbs: number | null;
+    fat: number | null;
+  } | null;
+  exercise?: {
+    caloriesBurned: number;
+  } | null;
+}
+
+export interface CustomFoodEntry {
+  name: string;
+  protein?: number;
+  carbs?: number;
+  fat?: number;
+  calories?: number;
+  log?: string | boolean;
+}
+
+export interface LogFoodEntry {
+  name: string;
+  meal?: string;
+  servings?: number;
+}
+
+export interface AutomationClient {
+  addQuickEntry(
+    entry: MacroEntry,
+    onStatus?: (msg: string) => void
+  ): Promise<void>;
+  getWeight(
+    dates: string[],
+    onStatus?: (msg: string) => void
+  ): Promise<WeightData[]>;
+  getDiary(
+    dates: string[],
+    onStatus?: (msg: string) => void,
+    scrapeTargets?: boolean
+  ): Promise<DiaryData[]>;
+  addCustomFood(
+    entry: CustomFoodEntry,
+    onStatus?: (msg: string) => void
+  ): Promise<void>;
+  logFood(entry: LogFoodEntry, onStatus?: (msg: string) => void): Promise<void>;
+}
+
+export interface PlaywrightExecutionResponse<T = unknown> {
+  success: boolean;
+  error?: string;
+  result?: T;
+  stderr?: string;
+}
+
+export interface AutomationRuntime {
+  liveViewUrl?: string | null;
+  execute<T = unknown>(
+    code: string,
+    timeoutSec?: number
+  ): Promise<PlaywrightExecutionResponse<T>>;
+  close(): Promise<void>;
+}
+
+export type AutomationRuntimeFactory = (
+  hasAutoCredentials: boolean
+) => Promise<AutomationRuntime>;

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,5 +1,5 @@
 import * as p from "@clack/prompts";
-import { getKernelClient } from "../kernel/client.js";
+import { getAutomationClient } from "../automation/client.js";
 import { formatKernelError } from "../kernel/errors.js";
 
 export interface AddCustomFoodOptions {
@@ -60,8 +60,8 @@ export async function addCustomFood(
   s.start("Connecting...");
 
   try {
-    const kernel = await getKernelClient();
-    await kernel.addCustomFood(
+    const client = await getAutomationClient();
+    await client.addCustomFood(
       {
         name,
         protein: options.protein,

--- a/src/commands/diary.ts
+++ b/src/commands/diary.ts
@@ -1,5 +1,6 @@
 import * as p from "@clack/prompts";
-import { getKernelClient, type DiaryData } from "../kernel/client.js";
+import { getAutomationClient } from "../automation/client.js";
+import type { DiaryData } from "../automation/types.js";
 import { formatKernelError } from "../kernel/errors.js";
 import { parseDate, parseRange, dateRange, todayStr } from "../utils/date.js";
 import { exportData } from "../cronometer/export.js";
@@ -46,10 +47,10 @@ export async function diary(options: DiaryOptions): Promise<void> {
   s?.start("Connecting...");
 
   try {
-    const kernel = await getKernelClient();
+    const client = await getAutomationClient();
 
     // When --targets is used, fetch exercise data concurrently with diary scraping
-    const diaryPromise = kernel.getDiary(
+    const diaryPromise = client.getDiary(
       dates,
       (msg) => s?.message(msg),
       options.targets

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -1,5 +1,5 @@
 import * as p from "@clack/prompts";
-import { getKernelClient } from "../kernel/client.js";
+import { getAutomationClient } from "../automation/client.js";
 import { formatKernelError } from "../kernel/errors.js";
 
 export interface LogOptions {
@@ -37,8 +37,8 @@ export async function log(name: string, options: LogOptions): Promise<void> {
   s.start("Connecting...");
 
   try {
-    const kernel = await getKernelClient();
-    await kernel.logFood(
+    const client = await getAutomationClient();
+    await client.logFood(
       {
         name,
         meal: options.meal,

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -7,6 +7,7 @@
 
 import * as p from "@clack/prompts";
 import Kernel from "@onkernel/sdk";
+import { loadConfig, saveConfig } from "../config.js";
 import { getCredential, setCredential } from "../credentials.js";
 
 /**
@@ -44,6 +45,7 @@ function mask(value: string): string {
  * Pressing Enter without typing keeps the existing value.
  */
 export async function login(): Promise<void> {
+  const existingConfig = loadConfig();
   const existingKey = getCredential("kernel-api-key");
   const existingEmail = getCredential("cronometer-username");
   const existingPassword = getCredential("cronometer-password");
@@ -56,40 +58,62 @@ export async function login(): Promise<void> {
     );
   }
 
-  // 1. Kernel API key
-  const apiKeyInput = await p.text({
-    message: "Kernel API key",
-    placeholder: existingKey ? mask(existingKey) : "sk-...",
-    defaultValue: existingKey ?? undefined,
+  // 1. Automation backend
+  const useKernelInput = await p.confirm({
+    message: "Use Kernel remote browser?",
+    initialValue: existingConfig.useKernel ?? true,
   });
 
-  if (p.isCancel(apiKeyInput)) {
+  if (p.isCancel(useKernelInput)) {
     p.cancel("Login cancelled.");
     process.exit(0);
   }
 
-  const apiKey = apiKeyInput || existingKey;
+  const useKernel = useKernelInput;
 
-  if (!apiKey) {
-    p.cancel("API key cannot be empty.");
-    process.exit(1);
-  }
+  // 2. Kernel API key
+  let apiKeyInput: string | symbol | undefined;
+  let apiKey: string | null | undefined = existingKey;
 
-  // Only validate if the key changed
-  if (apiKeyInput && apiKeyInput !== existingKey) {
-    const s = p.spinner();
-    s.start("Validating API key...");
-    try {
-      await validateKernelApiKey(apiKey);
-      s.stop("API key valid.");
-    } catch {
-      s.stop("API key invalid.");
-      p.cancel("Invalid API key. Check your key at https://kernel.sh");
+  if (useKernel) {
+    apiKeyInput = await p.text({
+      message: "Kernel API key",
+      placeholder: existingKey ? mask(existingKey) : "sk-...",
+      defaultValue: existingKey ?? undefined,
+    });
+
+    if (p.isCancel(apiKeyInput)) {
+      p.cancel("Login cancelled.");
+      process.exit(0);
+    }
+
+    apiKey = typeof apiKeyInput === "string" ? apiKeyInput : existingKey;
+
+    if (!apiKey) {
+      p.cancel("API key cannot be empty when Kernel is enabled.");
       process.exit(1);
+    }
+
+    // Only validate if the key changed
+    if (
+      typeof apiKeyInput === "string" &&
+      apiKeyInput &&
+      apiKeyInput !== existingKey
+    ) {
+      const s = p.spinner();
+      s.start("Validating API key...");
+      try {
+        await validateKernelApiKey(apiKey);
+        s.stop("API key valid.");
+      } catch {
+        s.stop("API key invalid.");
+        p.cancel("Invalid API key. Check your key at https://kernel.sh");
+        process.exit(1);
+      }
     }
   }
 
-  // 2. Cronometer email
+  // 3. Cronometer email
   const emailInput = await p.text({
     message: "Cronometer email",
     defaultValue: existingEmail ?? undefined,
@@ -111,7 +135,7 @@ export async function login(): Promise<void> {
     process.exit(1);
   }
 
-  // 3. Cronometer password
+  // 4. Cronometer password
   let password: string | undefined;
 
   if (existingPassword) {
@@ -159,13 +183,25 @@ export async function login(): Promise<void> {
     process.exit(1);
   }
 
-  // Store credentials
-  setCredential("kernel-api-key", apiKey);
+  // Store config and credentials
+  saveConfig({ ...existingConfig, useKernel });
+  if (apiKey) {
+    setCredential("kernel-api-key", apiKey);
+  }
   setCredential("cronometer-username", email);
   setCredential("cronometer-password", password);
 
   const changed: string[] = [];
-  if (apiKeyInput && apiKeyInput !== existingKey) changed.push("API key");
+  if (useKernel !== (existingConfig.useKernel ?? true)) {
+    changed.push("backend");
+  }
+  if (
+    typeof apiKeyInput === "string" &&
+    apiKeyInput &&
+    apiKeyInput !== existingKey
+  ) {
+    changed.push("API key");
+  }
   if (emailInput && emailInput !== existingEmail) changed.push("email");
   if (password !== existingPassword) changed.push("password");
 

--- a/src/commands/quick-add.ts
+++ b/src/commands/quick-add.ts
@@ -1,5 +1,5 @@
 import * as p from "@clack/prompts";
-import { getKernelClient } from "../kernel/client.js";
+import { getAutomationClient } from "../automation/client.js";
 import { formatKernelError } from "../kernel/errors.js";
 import { resolveDate } from "../utils/date.js";
 
@@ -60,8 +60,8 @@ export async function quickAdd(options: QuickAddOptions): Promise<void> {
   s.start("Connecting...");
 
   try {
-    const kernel = await getKernelClient();
-    await kernel.addQuickEntry(
+    const client = await getAutomationClient();
+    await client.addQuickEntry(
       {
         protein: options.protein,
         carbs: options.carbs,

--- a/src/commands/weight.ts
+++ b/src/commands/weight.ts
@@ -1,5 +1,6 @@
 import * as p from "@clack/prompts";
-import { getKernelClient, type WeightData } from "../kernel/client.js";
+import { getAutomationClient } from "../automation/client.js";
+import type { WeightData } from "../automation/types.js";
 import { formatKernelError } from "../kernel/errors.js";
 import { parseDate, parseRange, dateRange, todayStr } from "../utils/date.js";
 
@@ -43,8 +44,8 @@ export async function weight(options: WeightOptions): Promise<void> {
   s?.start("Connecting...");
 
   try {
-    const kernel = await getKernelClient();
-    const entries = await kernel.getWeight(dates, (msg) => s?.message(msg));
+    const client = await getAutomationClient();
+    const entries = await client.getWeight(dates, (msg) => s?.message(msg));
 
     s?.stop("Done.");
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 export interface CronoConfig {
   useKernel?: boolean;
   kernelProfile?: string;
+  playwrightHeadless?: boolean;
   defaultMeal?: string;
   gwtPermutation?: string;
   gwtHeader?: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import { homedir } from "os";
 import { join } from "path";
 
 export interface CronoConfig {
+  useKernel?: boolean;
   kernelProfile?: string;
   defaultMeal?: string;
   gwtPermutation?: string;
@@ -52,4 +53,11 @@ export function saveConfig(config: CronoConfig): void {
  */
 export function getSessionDir(): string {
   return join(CONFIG_DIR, "sessions");
+}
+
+/**
+ * Get the local Playwright profile directory.
+ */
+export function getPlaywrightProfileDir(): string {
+  return join(CONFIG_DIR, "playwright-profile");
 }

--- a/src/kernel/add-custom-food.ts
+++ b/src/kernel/add-custom-food.ts
@@ -307,22 +307,22 @@ export function buildAddCustomFoodCode(entry: CustomFoodEntry): string {
       }
       await page.waitForTimeout(200);
 
-      // Wait for serving size panel
-      try {
-        await page.waitForSelector('text="Serving Size"', { timeout: 5000 });
-      } catch {
-        return { success: false, error: 'Food created but Serving Size panel did not appear' };
-      }
-      await page.waitForTimeout(500);
-
       // Click "ADD TO DIARY"
-      const addClicked = await clickFirst([
+      const addToDiarySelectors = [
         'button:has-text("ADD TO DIARY")',
         'button:has-text("Add to Diary")',
         'text="ADD TO DIARY"',
         'text="Add to Diary"',
         'button[type="submit"]',
-      ], 'ADD TO DIARY button');
+      ];
+      const addButtonReady = await page.waitForSelector(addToDiarySelectors.join(', '), { timeout: 5000 })
+        .then(() => true)
+        .catch(() => false);
+      if (!addButtonReady) {
+        return { success: false, error: 'Food created but could not find "Add to Diary" button after selecting "' + foodName + '"' };
+      }
+
+      const addClicked = await clickFirst(addToDiarySelectors, 'ADD TO DIARY button');
       if (!addClicked) {
         return { success: false, error: 'Food created but could not find "Add to Diary" button' };
       }

--- a/src/kernel/client.ts
+++ b/src/kernel/client.ts
@@ -1,94 +1,30 @@
 /**
- * Kernel.sh browser automation client for Cronometer.
- *
- * Orchestrates the SDK to manage browser sessions, handle login,
- * and execute Playwright automation for diary entries.
- *
- * Each operation creates a fresh browser, logs in, performs the
- * action, and tears down.
+ * Kernel.sh browser automation runtime.
  */
 
-import * as p from "@clack/prompts";
 import Kernel from "@onkernel/sdk";
+import { createAutomationClient } from "../automation/runner.js";
+import type {
+  AutomationClient,
+  AutomationRuntime,
+  AutomationRuntimeFactory,
+  CustomFoodEntry,
+  DiaryData,
+  LogFoodEntry,
+  MacroEntry,
+  PlaywrightExecutionResponse,
+  WeightData,
+} from "../automation/types.js";
 import { getCredential } from "../credentials.js";
-import {
-  buildAutoLoginCode,
-  buildLoginCheckCode,
-  buildNavigateToLoginCode,
-} from "./login.js";
-import { buildQuickAddCode } from "./quick-add.js";
-import { buildAddCustomFoodCode } from "./add-custom-food.js";
-import { buildLogFoodCode } from "./log-food.js";
-import { buildDiaryCode } from "./diary.js";
-import { buildWeightCode } from "./weight.js";
 
-export interface MacroEntry {
-  protein?: number;
-  carbs?: number;
-  fat?: number;
-  alcohol?: number;
-  meal?: string;
-  date?: string;
-}
-
-export interface WeightData {
-  date: string;
-  weight: number | null;
-  unit: string;
-}
-
-export interface DiaryData {
-  date: string;
-  calories: number;
-  protein: number;
-  carbs: number;
-  fat: number;
-  targets?: {
-    calories: number | null;
-    protein: number | null;
-    carbs: number | null;
-    fat: number | null;
-  } | null;
-  exercise?: {
-    caloriesBurned: number;
-  } | null;
-}
-
-export interface CustomFoodEntry {
-  name: string;
-  protein?: number;
-  carbs?: number;
-  fat?: number;
-  calories?: number;
-  log?: string | boolean;
-}
-
-export interface LogFoodEntry {
-  name: string;
-  meal?: string;
-  servings?: number;
-}
-
-export interface KernelClient {
-  addQuickEntry(
-    entry: MacroEntry,
-    onStatus?: (msg: string) => void
-  ): Promise<void>;
-  getWeight(
-    dates: string[],
-    onStatus?: (msg: string) => void
-  ): Promise<WeightData[]>;
-  getDiary(
-    dates: string[],
-    onStatus?: (msg: string) => void,
-    scrapeTargets?: boolean
-  ): Promise<DiaryData[]>;
-  addCustomFood(
-    entry: CustomFoodEntry,
-    onStatus?: (msg: string) => void
-  ): Promise<void>;
-  logFood(entry: LogFoodEntry, onStatus?: (msg: string) => void): Promise<void>;
-}
+export type KernelClient = AutomationClient;
+export type {
+  CustomFoodEntry,
+  DiaryData,
+  LogFoodEntry,
+  MacroEntry,
+  WeightData,
+};
 
 /**
  * Create a Kernel client for Cronometer automation.
@@ -106,382 +42,43 @@ export async function getKernelClient(): Promise<KernelClient> {
         "  export KERNEL_API_KEY=your-key-here"
     );
   }
-  process.env["KERNEL_API_KEY"] = apiKey;
 
+  process.env["KERNEL_API_KEY"] = apiKey;
   const kernel = new Kernel();
 
-  return {
-    addQuickEntry: (entry: MacroEntry, onStatus?: (msg: string) => void) =>
-      addQuickEntry(kernel, entry, onStatus),
-    getWeight: (dates: string[], onStatus?: (msg: string) => void) =>
-      getWeight(kernel, dates, onStatus),
-    getDiary: (
-      dates: string[],
-      onStatus?: (msg: string) => void,
-      scrapeTargets?: boolean
-    ) => getDiary(kernel, dates, onStatus, scrapeTargets),
-    addCustomFood: (entry: CustomFoodEntry, onStatus?: (msg: string) => void) =>
-      addCustomFood(kernel, entry, onStatus),
-    logFood: (entry: LogFoodEntry, onStatus?: (msg: string) => void) =>
-      logFood(kernel, entry, onStatus),
+  return createAutomationClient(createKernelRuntimeFactory(kernel));
+}
+
+function createKernelRuntimeFactory(kernel: Kernel): AutomationRuntimeFactory {
+  return async (hasAutoCredentials: boolean) => {
+    const browser = await kernel.browsers.create({
+      headless: hasAutoCredentials,
+      stealth: true,
+      timeout_seconds: hasAutoCredentials ? 120 : 300,
+    });
+
+    return {
+      liveViewUrl: browser.browser_live_view_url,
+      execute: async <T = unknown>(
+        code: string,
+        timeoutSec = 60
+      ): Promise<PlaywrightExecutionResponse<T>> => {
+        const response = await kernel.browsers.playwright.execute(
+          browser.session_id,
+          {
+            code,
+            timeout_sec: timeoutSec,
+          }
+        );
+        return response as PlaywrightExecutionResponse<T>;
+      },
+      close: async () => {
+        try {
+          await kernel.browsers.deleteByID(browser.session_id);
+        } catch {
+          // Browser may already be cleaned up by Kernel.
+        }
+      },
+    } satisfies AutomationRuntime;
   };
-}
-
-/**
- * Execute the quick-add automation on Cronometer.
- * Creates a browser, logs in, performs the quick-add, then tears down.
- */
-async function addQuickEntry(
-  kernel: Kernel,
-  entry: MacroEntry,
-  onStatus?: (msg: string) => void
-): Promise<void> {
-  const username = getCredential("cronometer-username");
-  const password = getCredential("cronometer-password");
-  const hasAutoCreds = !!(username && password);
-
-  const browser = await kernel.browsers.create({
-    headless: hasAutoCreds,
-    stealth: true,
-    timeout_seconds: hasAutoCreds ? 120 : 300,
-  });
-
-  try {
-    // Log in to Cronometer
-    if (hasAutoCreds) {
-      await autoLogin(kernel, browser.session_id, username, password, onStatus);
-    } else {
-      await manualLogin(kernel, browser);
-    }
-
-    // Execute quick-add
-    onStatus?.("Adding quick entry...");
-    const result = await kernel.browsers.playwright.execute(
-      browser.session_id,
-      { code: buildQuickAddCode(entry), timeout_sec: 60 }
-    );
-
-    if (!result.success) {
-      throw new Error(`Automation failed: ${result.error ?? "Unknown error"}`);
-    }
-
-    const data = result.result as { success: boolean; error?: string };
-    if (!data.success) {
-      throw new Error(`Quick add failed: ${data.error ?? "Unknown error"}`);
-    }
-  } finally {
-    try {
-      await kernel.browsers.deleteByID(browser.session_id);
-    } catch {
-      // Browser may already be cleaned up by Kernel
-    }
-  }
-}
-
-/**
- * Execute the weight scraping automation on Cronometer.
- * Creates a browser, logs in, reads weight data, then tears down.
- */
-async function getWeight(
-  kernel: Kernel,
-  dates: string[],
-  onStatus?: (msg: string) => void
-): Promise<WeightData[]> {
-  const username = getCredential("cronometer-username");
-  const password = getCredential("cronometer-password");
-  const hasAutoCreds = !!(username && password);
-
-  const browser = await kernel.browsers.create({
-    headless: hasAutoCreds,
-    stealth: true,
-    timeout_seconds: hasAutoCreds ? 120 : 300,
-  });
-
-  try {
-    if (hasAutoCreds) {
-      await autoLogin(kernel, browser.session_id, username, password, onStatus);
-    } else {
-      await manualLogin(kernel, browser);
-    }
-
-    onStatus?.("Reading weight data...");
-    const result = await kernel.browsers.playwright.execute(
-      browser.session_id,
-      { code: buildWeightCode(dates), timeout_sec: 60 }
-    );
-
-    if (!result.success) {
-      throw new Error(`Automation failed: ${result.error ?? "Unknown error"}`);
-    }
-
-    const data = result.result as {
-      success: boolean;
-      entries?: WeightData[];
-      error?: string;
-    };
-    if (!data.success) {
-      throw new Error(`Weight read failed: ${data.error ?? "Unknown error"}`);
-    }
-
-    return data.entries ?? [];
-  } finally {
-    try {
-      await kernel.browsers.deleteByID(browser.session_id);
-    } catch {
-      // Browser may already be cleaned up by Kernel
-    }
-  }
-}
-
-/**
- * Execute the diary nutrition scraping automation on Cronometer.
- * Creates a browser, logs in, reads nutrition data, then tears down.
- */
-async function getDiary(
-  kernel: Kernel,
-  dates: string[],
-  onStatus?: (msg: string) => void,
-  scrapeTargets?: boolean
-): Promise<DiaryData[]> {
-  const username = getCredential("cronometer-username");
-  const password = getCredential("cronometer-password");
-  const hasAutoCreds = !!(username && password);
-
-  const browser = await kernel.browsers.create({
-    headless: hasAutoCreds,
-    stealth: true,
-    timeout_seconds: hasAutoCreds ? 120 : 300,
-  });
-
-  try {
-    if (hasAutoCreds) {
-      await autoLogin(kernel, browser.session_id, username, password, onStatus);
-    } else {
-      await manualLogin(kernel, browser);
-    }
-
-    onStatus?.("Reading diary data...");
-    const result = await kernel.browsers.playwright.execute(
-      browser.session_id,
-      { code: buildDiaryCode(dates, scrapeTargets), timeout_sec: 60 }
-    );
-
-    if (!result.success) {
-      throw new Error(`Automation failed: ${result.error ?? "Unknown error"}`);
-    }
-
-    const data = result.result as {
-      success: boolean;
-      entries?: DiaryData[];
-      error?: string;
-    };
-    if (!data.success) {
-      throw new Error(`Diary read failed: ${data.error ?? "Unknown error"}`);
-    }
-
-    return data.entries ?? [];
-  } finally {
-    try {
-      await kernel.browsers.deleteByID(browser.session_id);
-    } catch {
-      // Browser may already be cleaned up by Kernel
-    }
-  }
-}
-
-/**
- * Execute the custom food creation automation on Cronometer.
- * Creates a browser, logs in, creates the food, optionally logs it, then tears down.
- */
-async function addCustomFood(
-  kernel: Kernel,
-  entry: CustomFoodEntry,
-  onStatus?: (msg: string) => void
-): Promise<void> {
-  const username = getCredential("cronometer-username");
-  const password = getCredential("cronometer-password");
-  const hasAutoCreds = !!(username && password);
-
-  const browser = await kernel.browsers.create({
-    headless: hasAutoCreds,
-    stealth: true,
-    timeout_seconds: hasAutoCreds ? 120 : 300,
-  });
-
-  try {
-    if (hasAutoCreds) {
-      await autoLogin(kernel, browser.session_id, username, password, onStatus);
-    } else {
-      await manualLogin(kernel, browser);
-    }
-
-    onStatus?.("Creating custom food...");
-    const result = await kernel.browsers.playwright.execute(
-      browser.session_id,
-      { code: buildAddCustomFoodCode(entry), timeout_sec: 120 }
-    );
-
-    if (!result.success) {
-      throw new Error(`Automation failed: ${result.error ?? "Unknown error"}`);
-    }
-
-    const data = result.result as { success: boolean; error?: string };
-    if (!data.success) {
-      throw new Error(
-        `Custom food creation failed: ${data.error ?? "Unknown error"}`
-      );
-    }
-  } finally {
-    try {
-      await kernel.browsers.deleteByID(browser.session_id);
-    } catch {
-      // Browser may already be cleaned up by Kernel
-    }
-  }
-}
-
-/**
- * Execute the food logging automation on Cronometer.
- * Creates a browser, logs in, searches for the food, logs it, then tears down.
- */
-async function logFood(
-  kernel: Kernel,
-  entry: LogFoodEntry,
-  onStatus?: (msg: string) => void
-): Promise<void> {
-  const username = getCredential("cronometer-username");
-  const password = getCredential("cronometer-password");
-  const hasAutoCreds = !!(username && password);
-
-  const browser = await kernel.browsers.create({
-    headless: hasAutoCreds,
-    stealth: true,
-    timeout_seconds: hasAutoCreds ? 120 : 300,
-  });
-
-  try {
-    if (hasAutoCreds) {
-      await autoLogin(kernel, browser.session_id, username, password, onStatus);
-    } else {
-      await manualLogin(kernel, browser);
-    }
-
-    onStatus?.("Logging food to diary...");
-    const result = await kernel.browsers.playwright.execute(
-      browser.session_id,
-      { code: buildLogFoodCode(entry), timeout_sec: 60 }
-    );
-
-    if (!result.success) {
-      throw new Error(`Automation failed: ${result.error ?? "Unknown error"}`);
-    }
-
-    const data = result.result as { success: boolean; error?: string };
-    if (!data.success) {
-      throw new Error(`Food logging failed: ${data.error ?? "Unknown error"}`);
-    }
-  } finally {
-    try {
-      await kernel.browsers.deleteByID(browser.session_id);
-    } catch {
-      // Browser may already be cleaned up by Kernel
-    }
-  }
-}
-
-/**
- * Auto-login using stored Cronometer credentials.
- */
-async function autoLogin(
-  kernel: Kernel,
-  sessionId: string,
-  username: string,
-  password: string,
-  onStatus?: (msg: string) => void
-): Promise<void> {
-  onStatus?.("Logging into Cronometer...");
-
-  const result = await kernel.browsers.playwright.execute(sessionId, {
-    code: buildAutoLoginCode(username, password),
-    timeout_sec: 60,
-  });
-
-  const data = result.result as {
-    success: boolean;
-    loggedIn: boolean;
-    url: string;
-    error?: string;
-    loginError?: string | null;
-  };
-
-  if (!result.success || !data.loggedIn) {
-    const pageError = data.loginError?.toLowerCase() ?? "";
-    const isRateLimited =
-      pageError.includes("too many") ||
-      pageError.includes("rate limit") ||
-      pageError.includes("try again later") ||
-      pageError.includes("temporarily");
-
-    if (isRateLimited) {
-      throw new Error(
-        `Cronometer is rate-limiting login attempts. ${data.loginError}\n` +
-          "Please wait a few minutes and try again."
-      );
-    }
-
-    throw new Error(
-      `Auto-login failed: ${data.error ?? data.loginError ?? "Login verification failed"}.\n` +
-        "Your credentials may be incorrect. Run `crono login` to update them."
-    );
-  }
-}
-
-/**
- * Manual login: show a live browser view for the user to log in interactively.
- */
-async function manualLogin(
-  kernel: Kernel,
-  browser: { session_id: string; browser_live_view_url?: string | null }
-): Promise<void> {
-  p.log.warn("No stored Cronometer credentials found.");
-  p.log.info("Tip: run `crono login` to save credentials for automatic login.");
-
-  if (browser.browser_live_view_url) {
-    p.note(browser.browser_live_view_url, "Browser Live View");
-  }
-
-  await kernel.browsers.playwright.execute(browser.session_id, {
-    code: buildNavigateToLoginCode(),
-    timeout_sec: 30,
-  });
-
-  p.log.info("Please log into Cronometer in the browser above.");
-
-  const confirmation = await p.text({
-    message: "Press Enter once you've logged in...",
-    defaultValue: "",
-  });
-
-  if (p.isCancel(confirmation)) {
-    throw new Error("Login cancelled by user.");
-  }
-
-  const result = await kernel.browsers.playwright.execute(browser.session_id, {
-    code: buildLoginCheckCode(),
-    timeout_sec: 30,
-  });
-
-  const data = result.result as {
-    success: boolean;
-    loggedIn: boolean;
-    url: string;
-  };
-
-  if (!result.success || !data.loggedIn) {
-    throw new Error(
-      "Login verification failed. Make sure you're fully logged in and try again."
-    );
-  }
-
-  p.log.step("Logged in.");
 }

--- a/src/kernel/login.ts
+++ b/src/kernel/login.ts
@@ -8,15 +8,21 @@
 
 /**
  * Generate code that checks if the user is logged into Cronometer.
- * Navigates to /#diary and checks if we get redirected to a login page.
+ * Navigates to /#diary and checks if login UI is still presented.
  */
 export function buildLoginCheckCode(): string {
   return `
     await page.goto('https://cronometer.com/#diary', { waitUntil: 'domcontentloaded', timeout: 15000 });
     await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+    await page.waitForTimeout(1000);
     const url = page.url();
-    const isLoggedIn = url.includes('#diary') && !url.includes('/login') && !url.includes('/signin');
-    return { success: true, loggedIn: isLoggedIn, url };
+    ${buildLoginPresentedCheckCode()}
+    const diaryPresented = await page.evaluate(() => {
+      return !!document.querySelector('i.diary-date-previous, i.diary-date-next') ||
+        /Energy\\s+\\d+\\.?\\d*\\s*kcal/i.test(document.body.innerText);
+    }).catch(() => false);
+    const isLoggedIn = url.includes('#diary') && !url.includes('/login') && !url.includes('/signin') && !loginPresented && diaryPresented;
+    return { success: true, loggedIn: isLoggedIn, url, loginPresented, diaryPresented };
   `;
 }
 
@@ -122,7 +128,8 @@ export function buildAutoLoginCode(username: string, password: string): string {
     await page.waitForTimeout(500);
 
     const url = page.url();
-    const loggedIn = !url.includes('/login') && !url.includes('/signin');
+    ${buildLoginPresentedCheckCode()}
+    const loggedIn = !url.includes('/login') && !url.includes('/signin') && !loginPresented;
 
     // If still on login page, check for error messages (rate limit, wrong creds, etc.)
     let loginError = null;
@@ -147,5 +154,29 @@ export function buildAutoLoginCode(username: string, password: string): string {
     }
 
     return { success: true, loggedIn, url, loginError };
+  `;
+}
+
+function buildLoginPresentedCheckCode(): string {
+  return `
+    const loginPresented = await page.evaluate(() => {
+      const visible = (el) => {
+        const style = window.getComputedStyle(el);
+        return style && style.visibility !== 'hidden' && style.display !== 'none' && el.getClientRects().length > 0;
+      };
+      const hasVisibleSelector = (selector) =>
+        Array.from(document.querySelectorAll(selector)).some((el) => visible(el));
+      const hasLoginInput =
+        hasVisibleSelector('input[type="email"], input[name="username"], input[name="email"], #email, #username') ||
+        hasVisibleSelector('input[type="password"], input[name="password"], #password');
+      const hasLoginAction = Array.from(document.querySelectorAll('a, button'))
+        .filter((el) => visible(el))
+        .some((el) => {
+          const text = el.textContent?.replace(/\\s+/g, ' ').trim().toLowerCase() ?? '';
+          return ['log in', 'login', 'sign in', 'signin'].includes(text);
+        });
+
+      return hasLoginInput || hasLoginAction;
+    }).catch(() => false);
   `;
 }

--- a/src/playwright/client.ts
+++ b/src/playwright/client.ts
@@ -9,7 +9,7 @@ import type {
   AutomationClient,
   AutomationRuntime,
 } from "../automation/types.js";
-import { getPlaywrightProfileDir } from "../config.js";
+import { getPlaywrightProfileDir, loadConfig } from "../config.js";
 
 export async function getPlaywrightClient(): Promise<AutomationClient> {
   return createAutomationClient(createPlaywrightRuntime);
@@ -26,11 +26,14 @@ async function createPlaywrightRuntime(): Promise<AutomationRuntime> {
 }
 
 async function createContext(): Promise<BrowserContext> {
+  const config = loadConfig();
   const profileDir = getPlaywrightProfileDir();
   mkdirSync(profileDir, { recursive: true });
 
   return chromium.launchPersistentContext(profileDir, {
-    headless: false,
+    headless:
+      config.playwrightHeadless ??
+      (process.platform === "linux" && !process.env["DISPLAY"]),
   });
 }
 

--- a/src/playwright/client.ts
+++ b/src/playwright/client.ts
@@ -1,0 +1,62 @@
+/**
+ * Local Playwright automation runtime.
+ */
+
+import { mkdirSync } from "fs";
+import { chromium, type BrowserContext, type Page } from "playwright";
+import { createAutomationClient } from "../automation/runner.js";
+import type {
+  AutomationClient,
+  AutomationRuntime,
+} from "../automation/types.js";
+import { getPlaywrightProfileDir } from "../config.js";
+
+export async function getPlaywrightClient(): Promise<AutomationClient> {
+  return createAutomationClient(createPlaywrightRuntime);
+}
+
+async function createPlaywrightRuntime(): Promise<AutomationRuntime> {
+  const context = await createContext();
+  const page = context.pages()[0] ?? (await context.newPage());
+
+  return {
+    execute: (code: string) => executeScript(page, context, code),
+    close: () => context.close(),
+  };
+}
+
+async function createContext(): Promise<BrowserContext> {
+  const profileDir = getPlaywrightProfileDir();
+  mkdirSync(profileDir, { recursive: true });
+
+  return chromium.launchPersistentContext(profileDir, {
+    headless: false,
+  });
+}
+
+async function executeScript<T>(
+  page: Page,
+  context: BrowserContext,
+  code: string
+): Promise<{ success: boolean; result?: T; error?: string }> {
+  const browser = context.browser();
+  const execute = new Function(
+    "page",
+    "context",
+    "browser",
+    `return (async () => { ${code} })();`
+  ) as (
+    page: Page,
+    context: BrowserContext,
+    browser: ReturnType<BrowserContext["browser"]>
+  ) => Promise<T>;
+
+  try {
+    return { success: true, result: await execute(page, context, browser) };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/tests/kernel/add-custom-food.test.ts
+++ b/tests/kernel/add-custom-food.test.ts
@@ -92,6 +92,17 @@ describe("buildAddCustomFoodCode", () => {
     expect(code).toContain("Dinner");
   });
 
+  it("should log selected custom food without requiring the Serving Size panel", () => {
+    const code = buildAddCustomFoodCode({
+      name: "Test Food",
+      protein: 30,
+      log: "Snacks",
+    });
+    expect(code).toContain("addToDiarySelectors");
+    expect(code).toContain('after selecting "');
+    expect(code).not.toContain("Serving Size panel did not appear");
+  });
+
   it("should normalize meal name in log to title case", () => {
     const code = buildAddCustomFoodCode({
       name: "Test Food",

--- a/tests/kernel/login.test.ts
+++ b/tests/kernel/login.test.ts
@@ -17,6 +17,20 @@ describe("buildLoginCheckCode", () => {
     expect(code).toContain("loggedIn");
   });
 
+  it("should not trust the diary URL when login UI is shown", () => {
+    const code = buildLoginCheckCode();
+    expect(code).toContain("loginPresented");
+    expect(code).toContain("hasLoginInput");
+    expect(code).toContain("hasLoginAction");
+  });
+
+  it("should require actual diary UI before treating the session as logged in", () => {
+    const code = buildLoginCheckCode();
+    expect(code).toContain("diaryPresented");
+    expect(code).toContain("diary-date-previous");
+    expect(code).toContain("Energy\\s+\\d+");
+  });
+
   it("should return a result object", () => {
     const code = buildLoginCheckCode();
     expect(code).toContain("return {");
@@ -60,6 +74,12 @@ describe("buildAutoLoginCode", () => {
     const code = buildAutoLoginCode("user@test.com", "password123");
     expect(code).toContain("loggedIn");
     expect(code).toContain("/login");
+  });
+
+  it("should reject login success if login UI is still shown", () => {
+    const code = buildAutoLoginCode("user@test.com", "password123");
+    expect(code).toContain("loginPresented");
+    expect(code).toContain("!loginPresented");
   });
 
   it("should return a result object", () => {


### PR DESCRIPTION
Adds a backend abstraction so crono can run automation through either Kernel
  or a local Playwright browser, selected via config.