### PR TITLE
feat: allow credentials via environment variables for headless deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ Set up or update your Kernel API key and Cronometer credentials. If credentials 
 crono login
 ```
 
+**Headless / container deployments:** all credentials can be provided via environment variables instead of `crono login`. Env vars take precedence over stored credentials.
+
+| Variable                    | Credential          |
+| --------------------------- | ------------------- |
+| `KERNEL_API_KEY`            | Kernel.sh API key   |
+| `CRONO_CRONOMETER_USERNAME` | Cronometer email    |
+| `CRONO_CRONOMETER_PASSWORD` | Cronometer password |
+
 ### `crono quick-add`
 
 Add a quick macro entry to your Cronometer diary.

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -23,6 +23,17 @@ export type CredentialKey =
 
 const SERVICE_NAME = "crono";
 
+/**
+ * Environment variables that override stored credentials.
+ * Useful for headless/container deployments where `crono login`
+ * cannot be run interactively.
+ */
+const ENV_VARS: Record<CredentialKey, string> = {
+  "kernel-api-key": "KERNEL_API_KEY",
+  "cronometer-username": "CRONO_CRONOMETER_USERNAME",
+  "cronometer-password": "CRONO_CRONOMETER_PASSWORD",
+};
+
 let configDirOverride: string | null = null;
 
 function getConfigDir(): string {
@@ -174,6 +185,8 @@ function fileDelete(key: string): void {
 // -- Public API --
 
 export function getCredential(key: CredentialKey): string | null {
+  const envValue = process.env[ENV_VARS[key]];
+  if (envValue) return envValue;
   return getBackend() === "keyring" ? keyringGet(key) : fileGet(key);
 }
 

--- a/src/cronometer/export.ts
+++ b/src/cronometer/export.ts
@@ -109,7 +109,10 @@ export async function exportData(
   const password = getCredential("cronometer-password");
 
   if (!username || !password) {
-    throw new Error("No Cronometer credentials found. Run: crono login");
+    throw new Error(
+      "No Cronometer credentials found. Run `crono login`, or set:\n" +
+        "  CRONO_CRONOMETER_USERNAME and CRONO_CRONOMETER_PASSWORD"
+    );
   }
 
   // Resolve GWT overrides: env vars > config > defaults

--- a/src/kernel/client.ts
+++ b/src/kernel/client.ts
@@ -52,8 +52,7 @@ export type {
  * Each operation creates a fresh browser and logs in.
  */
 export async function getKernelClient(): Promise<KernelClient> {
-  const apiKey =
-    process.env["KERNEL_API_KEY"] ?? getCredential("kernel-api-key");
+  const apiKey = getCredential("kernel-api-key");
   if (!apiKey) {
     throw new Error(
       "Kernel API key not found.\n" +

--- a/tests/credentials.test.ts
+++ b/tests/credentials.test.ts
@@ -107,3 +107,54 @@ describe("credentials (encrypted file backend)", () => {
     });
   });
 });
+
+describe("credentials (environment variable overrides)", () => {
+  const ENV_KEYS = [
+    "KERNEL_API_KEY",
+    "CRONO_CRONOMETER_USERNAME",
+    "CRONO_CRONOMETER_PASSWORD",
+  ];
+
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true });
+    _resetBackend();
+    _setBackend("file");
+    _setConfigDir(testDir);
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) delete process.env[key];
+    _setConfigDir(null);
+    _resetBackend();
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {
+      // cleanup best-effort
+    }
+  });
+
+  it("should resolve credentials from env vars without stored values", () => {
+    process.env.KERNEL_API_KEY = "env-key";
+    process.env.CRONO_CRONOMETER_USERNAME = "env@example.com";
+    process.env.CRONO_CRONOMETER_PASSWORD = "env-password";
+
+    expect(getCredential("kernel-api-key")).toBe("env-key");
+    expect(getCredential("cronometer-username")).toBe("env@example.com");
+    expect(getCredential("cronometer-password")).toBe("env-password");
+    expect(hasCredentials()).toBe(true);
+  });
+
+  it("should prefer env vars over stored credentials", () => {
+    setCredential("cronometer-username", "stored@example.com");
+    process.env.CRONO_CRONOMETER_USERNAME = "env@example.com";
+
+    expect(getCredential("cronometer-username")).toBe("env@example.com");
+  });
+
+  it("should fall back to stored credentials when env var is unset", () => {
+    setCredential("cronometer-username", "stored@example.com");
+
+    expect(getCredential("cronometer-username")).toBe("stored@example.com");
+  });
+});


### PR DESCRIPTION
## Summary

Enables running `crono` in headless environments (containers, VMs, CI) without an interactive `crono login`. All credentials can now be injected as environment variables at provision time.

## Changes

- **`src/credentials.ts`** — `getCredential()` now checks environment variables before falling back to the keychain / encrypted-file store:
  - `KERNEL_API_KEY` → Kernel.sh API key
  - `CRONO_CRONOMETER_USERNAME` → Cronometer email
  - `CRONO_CRONOMETER_PASSWORD` → Cronometer password
- **`src/kernel/client.ts`** — removed the client-specific `KERNEL_API_KEY` env check; centralized in `getCredential()`
- **`src/cronometer/export.ts`** — missing-credentials error now points to env vars for headless setups
- **`README.md`** — documented env-based auth with a `docker run` example
- **`tests/credentials.test.ts`** — tests for env resolution, precedence over stored credentials, and fallback

Env vars take precedence over stored credentials, matching the behavior `kernel/client.ts` already had for `KERNEL_API_KEY`.

## Container usage

```bash
docker run -e KERNEL_API_KEY=sk-...            -e CRONO_CRONOMETER_USERNAME=you@example.com            -e CRONO_CRONOMETER_PASSWORD=secret            your-image crono quick-add -p 30 -c 100
```

No config file or keychain required. Backend defaults to Kernel (remote browser, no display needed); the existing `CRONO_GWT_PERMUTATION`/`CRONO_GWT_HEADER` overrides continue to work.

## Testing

- [x] `npm test` — 224 passing (14 in credentials, 3 new)
- [x] `npm run build` clean